### PR TITLE
Fix motion profiles longer than 512 not executing correctly

### DIFF
--- a/src/org/hammerhead226/sharkmacro/Constants.java
+++ b/src/org/hammerhead226/sharkmacro/Constants.java
@@ -23,6 +23,7 @@ public final class Constants {
 	public static final String PROFILE_STORAGE_DIRECTORY = "/home/lvuser/profiles";
 
 	public static final int MINIMUM_POINTS_IN_TALON = 5;
+	public static final int TALON_TOP_BUFFER_MAX_COUNT = 512;
 	public static final double ENCODER_COUNTS_PER_REV = 4096.0;
 
 	// Actions

--- a/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileHandler.java
+++ b/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileHandler.java
@@ -26,6 +26,11 @@ public class ProfileHandler implements Cloneable {
 	 * The motion profile to execute.
 	 */
 	private double[][] profile;
+	
+	/**
+	 * Represents the current point being streamed from the profile.
+	 */
+	int profileIndex = 0;
 
 	/**
 	 * The PID gains profile {@link #talon} will use to execute the motion profile.s
@@ -166,14 +171,13 @@ public class ProfileHandler implements Cloneable {
 		talon.set(ControlMode.MotionProfile, mode.value);
 	}
 
+	
 	/**
 	 * Fill the Talon's top-level buffer with a given motion profile.
 	 * 
 	 * @param gainsProfile
 	 *            the PID gains profile to use to execute the motion profile
 	 */
-	int profileIndex = 0;
-
 	private void fillTalonWithMotionProfile(int gainsProfile) {
 
 		TrajectoryPoint point = new TrajectoryPoint();

--- a/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileHandler.java
+++ b/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileHandler.java
@@ -132,8 +132,6 @@ public class ProfileHandler implements Cloneable {
 	public void manage() {
 		fillTalonWithMotionProfile(gainsProfile);
 		talon.getMotionProfileStatus(status);
-		System.out.println(talon.getDeviceID() + ": " + status.btmBufferCnt + ", " + status.topBufferCnt + " - "
-				+ status.isUnderrun);
 
 		switch (executionState) {
 		case WAITING:


### PR DESCRIPTION
Trajectory points are now streamed to the talon's top-level buffer during execution instead of being dumped all at once.