### PR TITLE
Njaison/updated ctre

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. OpenCSV (tested on 4.1)
 2. Apache Commons Lang (tested on 3.7)
 3. WPILibJ
-4. Cross The Road Electronics Phoenix Lib
+4. Cross The Road Electronics Phoenix Lib(5.8.1)
 
 ## Installation (for FRC Eclipse)
 

--- a/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileHandler.java
+++ b/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileHandler.java
@@ -297,7 +297,7 @@ public class ProfileHandler {
 	 */
 	private TrajectoryDuration toTrajectoryDuration(int durationMs) {
 		TrajectoryDuration dur = TrajectoryDuration.Trajectory_Duration_0ms;
-		dur = dur.valueOf(durationMs);
+		dur = TrajectoryDuration.valueOf(durationMs);
 		if (dur.value != durationMs) {
 			DriverStation.getInstance();
 			DriverStation.reportError(

--- a/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileRecorder.java
+++ b/src/org/hammerhead226/sharkmacro/motionprofiles/ProfileRecorder.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 import org.hammerhead226.sharkmacro.Constants;
 
-import com.ctre.CANTalon;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 
 import edu.wpi.first.wpilibj.Notifier;

--- a/src/org/hammerhead226/sharkmacro/motionprofiles/Recording.java
+++ b/src/org/hammerhead226/sharkmacro/motionprofiles/Recording.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 import org.hammerhead226.sharkmacro.Constants;
 
-import com.ctre.CANTalon;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 
 /**


### PR DESCRIPTION
TrajectoryDuration is now accessed in a static way and CTRE version number is added to readme